### PR TITLE
Ambiguous occurrence ‘defaultTimeLocale’

### DIFF
--- a/Codec/MIME/ContentType/Text/Directory.hs
+++ b/Codec/MIME/ContentType/Text/Directory.hs
@@ -30,7 +30,6 @@ module Codec.MIME.ContentType.Text.Directory
     , printDirectory, printDirectory', printProperty) where
 
 import Data.Time
-import System.Locale
 import Data.Char (toLower)
 import Data.Maybe (fromJust)
 import Text.Regex.PCRE.ByteString.Lazy
@@ -38,7 +37,7 @@ import qualified Codec.Binary.Base64.String as Base64
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.ByteString.Lazy.Char8.Caseless as I
 import qualified Data.Map as Map
-import Control.Monad (liftM)
+import Control.Monad (liftM, ap)
 import System.IO.Unsafe
 
 
@@ -126,8 +125,15 @@ unfoldLines s | B.null s = []
 
 newtype P a = P { unP :: B.ByteString -> (a, B.ByteString) }
 
+instance Functor P where
+    fmap = liftM
+
+instance Applicative P where
+    pure x = P $ \s -> (x, s)
+    (<*>) = ap
+
 instance Monad P where
-    return x = P $ \s -> (x, s)
+    return = pure
     m >>= k = P $ \s -> let (a, s') = unP m s in unP (k a) s'
 
 p :: B.ByteString   -- ^ Text of the regular expression.


### PR DESCRIPTION
[2 of 2] Compiling Codec.MIME.ContentType.Text.Directory ( Codec/MIME/ContentType/Text/Directory.hs, dist/build/Codec/MIME/ContentType/Text/Directory.o )

Codec/MIME/ContentType/Text/Directory.hs:256:29:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Codec/MIME/ContentType/Text/Directory.hs:32:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Codec/MIME/ContentType/Text/Directory.hs:33:1-20
